### PR TITLE
file upload: normalize filename

### DIFF
--- a/libs/remote_tools/remote_handler.js
+++ b/libs/remote_tools/remote_handler.js
@@ -16,7 +16,8 @@ remote_handler.prototype.upload_to_filesystem_by_file = function (file, timestam
 
 	// apply timestamp to file's name if it is requested by timestamp parameter
 	var filename = timestamp ? timestamp_filename(file.name) : file.name
-
+	// normalize filename (no spaces, exotic chars)
+	filename = filename.replace(/[^\w\.]+/ig, '')
 	return enduro.filesystem.upload('direct_uploads/' + filename, file.path)
 }
 


### PR DESCRIPTION
remove whitespace, äöüß ... etc. from filename.

When uploading images to Enduro we should make sure the filename is "normalized"