### PR TITLE
Add links to other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 Enduro is minimalistic, lean & mean, node.js cms. See more at [enduro.js website](http://www.endurojs.com/)
 
+**Other repositories:** Enduro • [samples](https://github.com/Gottwik/enduro_samples) • [Enduro admin](https://github.com/Gottwik/enduro_admin) • [endurojs.com site](https://github.com/Gottwik/enduro_website)
+
 ![enduro admin](http://i.imgur.com/3TdMJlY.jpg)
 ![enduro admin](http://i.imgur.com/4PHp7me.jpg)
 ![enduro admin](http://i.imgur.com/4OheTyl.jpg)


### PR DESCRIPTION
> This and other recent pull requests simply add wiki-like links to other enduro repos.
> I often find myself navigating between these repos through @Gottwik profile :)
> I feel they should be linked to each other 'cause enduro admin and enduro itself are too tied to each 
other, and linking to samples and website enables better onboarding.

Other PRs: https://github.com/Gottwik/enduro_website/pull/6 • https://github.com/Gottwik/enduro_samples/pull/1 • https://github.com/Gottwik/enduro_admin/pull/10