### PR TITLE
get_outstanding_changes should return something if juicebox is disabled

### DIFF
--- a/libs/admin_api/get_outstanding_changes.js
+++ b/libs/admin_api/get_outstanding_changes.js
@@ -13,6 +13,9 @@ const admin_sessions = require(enduro.enduro_path + '/libs/admin_utilities/admin
 api_call.prototype.call = function (req, res, enduro_server) {
 	admin_sessions.get_user_by_session(req.query.sid)
 		.then((user) => {
+			if (!enduro.config.juicebox_enabled) {
+				return {}
+			}
 			return juicebox.diff_current_to_latest_juicebox()
 		}, () => {
 			res.sendStatus(401)


### PR DESCRIPTION
`admin_api/get_outstanding_changes` hangs when juicebox is disabled