### PR TITLE
Improve flat_db

### DIFF
--- a/libs/flat_db/flat.js
+++ b/libs/flat_db/flat.js
@@ -18,7 +18,6 @@ const flat_helpers = require(enduro.enduro_path + '/libs/flat_db/flat_helpers')
 const log_clusters = require(enduro.enduro_path + '/libs/log_clusters/log_clusters')
 const brick_processors = require(enduro.enduro_path + '/libs/bricks/brick_processors')
 
-
 // * ———————————————————————————————————————————————————————— * //
 // * 	Save cms file
 // *	@param {String} filename - Path to file without extension, relative to /cms folder
@@ -45,7 +44,7 @@ flat.prototype.save = function (filename, contents) {
 		}
 
 		// formats js file so it can be edited by hand later
-		const prettyString = stringify_object(flatObj, {indent: '	', singleQuotes: true})
+		const prettyString = '(' + stringify_object(flatObj, {indent: '	', singleQuotes: true}) + ')'
 
 		// save cms file
 		flat_helpers.ensure_directory_existence(fullpath_to_cms_file)
@@ -87,21 +86,17 @@ flat.prototype.load = function (filename, is_full_absolute_path) {
 			resolve({})
 		} else {
 			fs.readFile(fullpath_to_cms_file, function (err, raw_context_data) {
-				if (err) { reject() }
-
-				// check if file is empty. return empty object if so
-				if (raw_context_data == '') {
-					return resolve({})
+				if (err) {
+					console.log(err)
+					reject()
 				}
 
 				// strip whitespace
 				raw_context_data = raw_context_data.toString().trim()
 
-				// wraps content in curly braces if it isn't already wrapped
-				// the file will still be saved with braces but might help some people if
-				// they forget to include the braces
-				if (raw_context_data[0] != '{') {
-					raw_context_data = '{' + raw_context_data + '}'
+				// check if file is empty. return empty object if so
+				if (raw_context_data == '') {
+					return resolve({})
 				}
 
 				// convert the string-based javascript into an object
@@ -113,7 +108,7 @@ flat.prototype.load = function (filename, is_full_absolute_path) {
 					log_clusters.log('malformed_context_file', filename)
 				}
 
-				// brick_processors enable bricks(plugins) to manipulate the context just before
+				// brick_processors enable bricks (plugins) to manipulate the context just before
 				// page rendering happens
 				return brick_processors.process('cms_context_processor', context)
 					.then((proccessed_context) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,14 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
       "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-red": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
@@ -1516,6 +1524,11 @@
         }
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -1619,6 +1632,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colors": {
       "version": "1.0.3",
@@ -2323,9 +2341,9 @@
       }
     },
     "enduro_admin": {
-      "version": "1.0.72",
-      "resolved": "https://registry.npmjs.org/enduro_admin/-/enduro_admin-1.0.72.tgz",
-      "integrity": "sha512-/9J4J1NWFtHINwSE8qA3V2+PGZtYCUfRj3C8P//gjeXtaitfLQ6edBgKcjGqNovzMTKleBXYeVO+eWhXcDm22w=="
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/enduro_admin/-/enduro_admin-1.0.73.tgz",
+      "integrity": "sha512-TQJEQ38nPz8MEvoKWF1Os+Kr25xyxgL8JXkOo9coKRaiF8YaGQ7NLA17XN8OfkZzVCp2NbyX+CsS9w0BhdBudA=="
     },
     "engine.io-client": {
       "version": "3.1.4",
@@ -2564,6 +2582,34 @@
           "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
           "dev": true
         },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.0.0",
+            "chalk": "2.3.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.1.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -2579,6 +2625,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -2921,12 +2977,13 @@
       }
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
       "requires": {
+        "chardet": "0.4.2",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
         "tmp": "0.0.33"
       }
     },
@@ -3188,9 +3245,9 @@
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -4535,67 +4592,26 @@
       }
     },
     "gulp-autoprefixer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
-      "integrity": "sha1-dSMAUc0NFxND14O36bXREg7u+bA=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-4.1.0.tgz",
+      "integrity": "sha1-Bkr3PMAsrayP800L+T/9+5TqEqo=",
       "requires": {
-        "autoprefixer": "6.7.7",
-        "gulp-util": "3.0.8",
-        "postcss": "5.2.17",
+        "autoprefixer": "7.1.0",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "postcss": "6.0.1",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
-        "autoprefixer": {
-          "version": "6.7.7",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-          "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+        "fancy-log": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+          "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000710",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.17",
-            "postcss-value-parser": "3.3.0"
-          }
-        },
-        "browserslist": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-          "requires": {
-            "caniuse-db": "1.0.30000710",
-            "electron-to-chromium": "1.3.17"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
-          }
-        },
-        "postcss": {
-          "version": "5.2.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-          "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
-          "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.1.9",
-            "source-map": "0.5.6",
-            "supports-color": "3.2.3"
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "time-stamp": "1.1.0"
           }
         }
       }
@@ -4718,11 +4734,11 @@
       }
     },
     "gulp-flatten": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.3.1.tgz",
-      "integrity": "sha1-Uef+wTozxARXjRjBWJ0bW8Rf4dY=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.4.0.tgz",
+      "integrity": "sha512-eg4spVTAiv1xXmugyaCxWne1oPtNG0UHEtABx5W8ScLiqAYceyYm6GYA36x0Qh8KOIXmAZV97L2aYGnKREG3Sg==",
       "requires": {
-        "gulp-util": "3.0.8",
+        "plugin-error": "0.1.2",
         "through2": "2.0.3"
       }
     },
@@ -5847,15 +5863,15 @@
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
+      "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
       "requires": {
         "ansi-escapes": "3.0.0",
         "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -5871,6 +5887,16 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "external-editor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+          "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+          "requires": {
+            "chardet": "0.4.2",
+            "iconv-lite": "0.4.19",
+            "tmp": "0.0.33"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -6286,11 +6312,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
-    },
-    "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
     },
     "jsesc": {
       "version": "1.3.0",

--- a/scaffolding/test/cms/non_braced_content.js
+++ b/scaffolding/test/cms/non_braced_content.js
@@ -1,4 +1,0 @@
-toys: {
-	lego: 'awesome',
-	duplo: 'great for 2y olds'
-}

--- a/scaffolding/test_stylus/cms/non_braced_content.js
+++ b/scaffolding/test_stylus/cms/non_braced_content.js
@@ -1,4 +1,0 @@
-toys: {
-	lego: 'awesome',
-	duplo: 'great for 2y olds'
-}

--- a/test/flat_test/flat_test.js
+++ b/test/flat_test/flat_test.js
@@ -206,14 +206,6 @@ describe('flat db data access', function () {
 			})
 	})
 
-	it('should load cms file that is not wrapped in curly braces', function () {
-		return flat.load('non_braced_content')
-			.then((non_braced_content) => {
-				expect(non_braced_content).to.be.an('object')
-				expect(non_braced_content).to.have.property('toys')
-			})
-	})
-
 	after(function () {
 		return test_utilities.after()
 	})


### PR DESCRIPTION
* remove support + tests for non-braced content;
* write cms files in parentheses;
* better handling of empty files with whitespace.

Strictly, **this is a breaking change**.

Wrapping all the cms code in parentheses makes the code look like this:
```
({
  oh: 'hi'
})
```
so it becomes a valid JS code and IDEs stop complaining on them. *.js files without parentheses is still a valid format for Enduro.

This is mainly inspired by [this issue](https://github.com/Gottwik/Enduro/issues/204).

Since all the tests are failing now, I can't tell if this pull request is safe. It works good on my projects, though.