### PR TITLE
updating gulp wildcard

### DIFF
--- a/libs/build_tools/gulp_tasks.js
+++ b/libs/build_tools/gulp_tasks.js
@@ -108,7 +108,7 @@ function browsersync_start (norefresh) {
 	if (!enduro.flags.nowatch) {
 
 		// Watch for any js changes
-		watch([enduro.project_path + '/assets/js/*.js'], () => { gulp.start(js_handler) })
+		watch([enduro.project_path + '/assets/js/**/*.js'], () => { gulp.start(js_handler) })
 
 		// Watch for sass or less changes
 		watch(


### PR DESCRIPTION
Currently Enduro does not react to changes in `assets/js/randomFolder/randomFile.js`. Changing the selector in gulp_tasks will fix that.