### PR TITLE
support for compile file extensions .sass and .scss in assets css folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 enduro_secret.json
 /testfolder
 /t
+.idea/

--- a/libs/build_tools/sass_handler.js
+++ b/libs/build_tools/sass_handler.js
@@ -25,7 +25,7 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 
 		logger.timestamp('Sass compiling started', 'enduro_events')
 
-		return gulp.src(enduro.project_path + '/assets/css/*.scss')
+		return gulp.src(enduro.project_path + '/assets/css/*.{scss,sass}')
 			.pipe(bulkSass())
 			.pipe(sourcemaps.init())
 			.pipe(sass())


### PR DESCRIPTION
Hello! 
Due to flexibility and preference purpouse I use .sass extension, this file extension was not support inside enduro.js before.
Then I've just added the {sass,scss} extensions to the sass_handler.js file.
bye!