### PR TITLE
Minification

### DIFF
--- a/cli_commands/render.js
+++ b/cli_commands/render.js
@@ -2,6 +2,10 @@ module.exports = {
 	command: ['render', 'r'],
 	desc: 'renders all static files',
 	builder: {
+		'nominify': {
+			alias: 'm',
+			describe: 'Turns off file minification'
+		},
 		'nojuice': {
 			alias: 'j',
 			describe: 'no-juice',

--- a/cli_commands/start.js
+++ b/cli_commands/start.js
@@ -3,6 +3,10 @@ module.exports = {
 	command: 'start',
 	desc: 'starts production server',
 	builder: {
+		'nominify': {
+			alias: 'm',
+			describe: 'Turns off file minification'
+		},
 		'nojuice': {
 			alias: 'j',
 			describe: 'no-juice',

--- a/libs/build_tools/js_handler.js
+++ b/libs/build_tools/js_handler.js
@@ -48,7 +48,7 @@ js_handler.prototype.init = function (gulp, browser_sync) {
 					logger.timestamp('JS compiling finished', 'enduro_events')
 				})
 				.pipe(gulpif(enduro.config.uglify, rename({ suffix: '.min' })))
-				.pipe(gulpif(isProduction, uglify()))
+				.pipe(gulpif(isProduction(), uglify()))
 				.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/js'))
 		} else {
 			logger.timestamp('js compiling not enabled, add babel options to enduro.json to enable')

--- a/libs/build_tools/js_handler.js
+++ b/libs/build_tools/js_handler.js
@@ -13,7 +13,7 @@ const sourcemaps = require('gulp-sourcemaps')
 const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs-extra'))
 const isProduction = () => {
-	return enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render'
+	return (enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render') && !enduro.flags.nominify
 }
 
 // * enduro dependencies
@@ -23,8 +23,8 @@ const logger = require(enduro.enduro_path + '/libs/logger')
 js_handler.prototype.init = function (gulp, browser_sync) {
 
 	// stores task name
-	const js_handler_task_name = 'js';
-	gulp.task(js_handler_task_name, function() {
+	const js_handler_task_name = 'js'
+	gulp.task(js_handler_task_name, function () {
 		if (enduro.config.babel || enduro.config.uglify) {
 			logger.timestamp('JS compiling started', 'enduro_events')
 			const babelConfig = enduro.config.babel || {
@@ -61,7 +61,7 @@ js_handler.prototype.init = function (gulp, browser_sync) {
 		}
 	})
 
-	return js_handler_task_name;
+	return js_handler_task_name
 }
 
 module.exports = new js_handler()

--- a/libs/build_tools/js_handler.js
+++ b/libs/build_tools/js_handler.js
@@ -12,6 +12,9 @@ const gulpif = require('gulp-if')
 const sourcemaps = require('gulp-sourcemaps')
 const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs-extra'))
+const isProduction = () => {
+	return enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render'
+}
 
 // * enduro dependencies
 const flat_helpers = require(enduro.enduro_path + '/libs/flat_db/flat_helpers')
@@ -28,8 +31,8 @@ js_handler.prototype.init = function (gulp, browser_sync) {
 				presets: ['es2015']
 			}
 			return gulp.src([enduro.project_path + '/assets/js/*.js',
-							'!' + enduro.project_path + '/assets/js/*.min.js',
-							'!' + enduro.project_path + '/assets/js/handlebars.js'])
+				'!' + enduro.project_path + '/assets/js/*.min.js',
+				'!' + enduro.project_path + '/assets/js/handlebars.js'])
 				.pipe(sourcemaps.init())
 				.pipe(gulpif(enduro.config.babel, babel(babelConfig)))
 				.on('error', function (err) {
@@ -45,7 +48,7 @@ js_handler.prototype.init = function (gulp, browser_sync) {
 					logger.timestamp('JS compiling finished', 'enduro_events')
 				})
 				.pipe(gulpif(enduro.config.uglify, rename({ suffix: '.min' })))
-				.pipe(gulpif(enduro.config.uglify, uglify()))
+				.pipe(gulpif(isProduction, uglify()))
 				.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/js'))
 		} else {
 			logger.timestamp('js compiling not enabled, add babel options to enduro.json to enable')

--- a/libs/build_tools/less_handler.js
+++ b/libs/build_tools/less_handler.js
@@ -36,7 +36,7 @@ less_handler.prototype.init = function (gulp, browser_sync) {
 			.pipe(gulpif(isProduction(), sourcemaps.init()))
 			.pipe(less({
 				paths: enduro.config.less && enduro.config.less.paths || [],
-				plugins: [ autoprefixer, (isProduction ? cleanCSS : null) ]
+				plugins: [ autoprefixer, (isProduction() ? cleanCSS : null) ]
 			}))
 			.on('error', function (err) {
 				logger.err_blockStart('Less error')

--- a/libs/build_tools/sass_handler.js
+++ b/libs/build_tools/sass_handler.js
@@ -13,7 +13,7 @@ const gulpif = require('gulp-if')
 const sourcemaps = require('gulp-sourcemaps')
 const autoprefixer = require('gulp-autoprefixer')
 const isProduction = () => {
-	return enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render'
+	return (enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render') && !enduro.flags.nominify
 }
 
 // * enduro dependencies
@@ -33,7 +33,7 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 			.pipe(bulkSass())
 			.pipe(gulpif(!isProduction, sourcemaps.init()))
 			.pipe(sass({
-				outputStyle: isProduction ? 'compressed' : 'normal'
+				outputStyle: isProduction ? 'compressed' : 'nested'
 			}))
 			.on('error', function (err) {
 				logger.err_blockStart('Sass error')
@@ -49,6 +49,7 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 			.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/css'))
 			.pipe(browser_sync.stream())
 			.on('end', () => {
+				console.log(enduro.flags)
 				logger.timestamp('Sass compiling finished', 'enduro_events')
 			})
 

--- a/libs/build_tools/sass_handler.js
+++ b/libs/build_tools/sass_handler.js
@@ -9,8 +9,12 @@ const sass_handler = function () {}
 // * vendor dependencies
 const bulkSass = require('gulp-sass-bulk-import')
 const sass = require('gulp-sass')
+const gulpif = require('gulp-if')
 const sourcemaps = require('gulp-sourcemaps')
 const autoprefixer = require('gulp-autoprefixer')
+const isProduction = () => {
+  return enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render'
+}
 
 // * enduro dependencies
 const logger = require(enduro.enduro_path + '/libs/logger')
@@ -27,8 +31,10 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 
 		return gulp.src(enduro.project_path + '/assets/css/*.scss')
 			.pipe(bulkSass())
-			.pipe(sourcemaps.init())
-			.pipe(sass())
+			.pipe(gulpif(!isProduction, sourcemaps.init()))
+			.pipe(sass({
+        outputStyle: isProduction ? 'compressed' : 'normal'
+      }))
 			.on('error', function (err) {
 				logger.err_blockStart('Sass error')
 				logger.err(err.message)
@@ -39,7 +45,7 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 				browsers: ['last 2 versions'],
 				cascade: false,
 			}))
-			.pipe(sourcemaps.write())
+			.pipe(gulpif(!isProduction, sourcemaps.write()))
 			.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/css'))
 			.pipe(browser_sync.stream())
 			.on('end', () => {

--- a/libs/build_tools/sass_handler.js
+++ b/libs/build_tools/sass_handler.js
@@ -49,7 +49,6 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 			.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/css'))
 			.pipe(browser_sync.stream())
 			.on('end', () => {
-				console.log(isProduction())
 				logger.timestamp('Sass compiling finished', 'enduro_events')
 			})
 

--- a/libs/build_tools/sass_handler.js
+++ b/libs/build_tools/sass_handler.js
@@ -13,7 +13,7 @@ const gulpif = require('gulp-if')
 const sourcemaps = require('gulp-sourcemaps')
 const autoprefixer = require('gulp-autoprefixer')
 const isProduction = () => {
-  return enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render'
+	return enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render'
 }
 
 // * enduro dependencies
@@ -33,8 +33,8 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 			.pipe(bulkSass())
 			.pipe(gulpif(!isProduction, sourcemaps.init()))
 			.pipe(sass({
-        outputStyle: isProduction ? 'compressed' : 'normal'
-      }))
+				outputStyle: isProduction ? 'compressed' : 'normal'
+			}))
 			.on('error', function (err) {
 				logger.err_blockStart('Sass error')
 				logger.err(err.message)

--- a/libs/build_tools/sass_handler.js
+++ b/libs/build_tools/sass_handler.js
@@ -31,9 +31,9 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 
 		return gulp.src(enduro.project_path + '/assets/css/*.scss')
 			.pipe(bulkSass())
-			.pipe(gulpif(!isProduction, sourcemaps.init()))
+			.pipe(gulpif(!isProduction(), sourcemaps.init()))
 			.pipe(sass({
-				outputStyle: isProduction ? 'compressed' : 'nested'
+				outputStyle: isProduction() ? 'compressed' : 'nested'
 			}))
 			.on('error', function (err) {
 				logger.err_blockStart('Sass error')
@@ -45,11 +45,11 @@ sass_handler.prototype.init = function (gulp, browser_sync) {
 				browsers: ['last 2 versions'],
 				cascade: false,
 			}))
-			.pipe(gulpif(!isProduction, sourcemaps.write()))
+			.pipe(gulpif(!isProduction(), sourcemaps.write()))
 			.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/css'))
 			.pipe(browser_sync.stream())
 			.on('end', () => {
-				console.log(enduro.flags)
+				console.log(isProduction())
 				logger.timestamp('Sass compiling finished', 'enduro_events')
 			})
 

--- a/libs/build_tools/stylus_handler.js
+++ b/libs/build_tools/stylus_handler.js
@@ -10,6 +10,10 @@ const stylus_handler = function () {}
 const stylus = require('gulp-stylus')
 const sourcemaps = require('gulp-sourcemaps')
 const autoprefixer = require('autoprefixer-stylus')
+const gulpif = require('gulp-if')
+const isProduction = () => {
+	return (enduro.flags._[0] === 'start' || enduro.flags._[0] === 'render') && !enduro.flags.nominify
+}
 
 // * enduro dependencies
 const logger = require(enduro.enduro_path + '/libs/logger')
@@ -25,9 +29,10 @@ stylus_handler.prototype.init = function (gulp, browser_sync) {
 		logger.timestamp('Stylus compiling started', 'enduro_events')
 
 		return gulp.src(enduro.project_path + '/assets/css/*.styl')
-			.pipe(sourcemaps.init())
+			.pipe(gulpif(!isProduction(), sourcemaps.init()))
 			.pipe(stylus({
-				use: [ autoprefixer('last 5 versions') ]
+				use: [ autoprefixer('last 5 versions') ],
+				compress: isProduction() ? true : false
 			}))
 			.on('error', function (err) {
 				logger.err_blockStart('Stylus error')
@@ -35,7 +40,7 @@ stylus_handler.prototype.init = function (gulp, browser_sync) {
 				logger.err_blockEnd()
 				this.emit('end')
 			})
-			.pipe(sourcemaps.write())
+			.pipe(gulpif(!isProduction(), sourcemaps.write()))
 			.pipe(gulp.dest(enduro.project_path + '/' + enduro.config.build_folder + '/assets/css'))
 			.pipe(browser_sync.stream())
 			.on('end', () => {

--- a/libs/cli_tools/flag_handler.js
+++ b/libs/cli_tools/flag_handler.js
@@ -40,6 +40,10 @@ const FLAG_MAP = {
 	nojuice: {
 		label: 'nojuice',
 		message: 'will turn off juicebox'
+	},
+	nominify: {
+		label: 'nominify',
+		message: 'will not minify css and js files'
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "handlebars": "^4.0.11",
     "inquirer": "^4.0.0",
     "less-plugin-autoprefix": "^1.5.1",
+    "less-plugin-clean-css": "^1.5.1",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "moment": "^2.20.1",


### PR DESCRIPTION
I really love enduro, how minimalistic and fast it is, but it always annoyed me how even when deploying for production, it would generate sourcemaps and not minify my assets, effectively doubling (at least) the file size. When using it for deploying static websites, I'd just use additional gulp tasks to minify the generated files. However recently I wanted to try deploying it as a cms with admin panel, so I thought I'd try modifying enduro itself, so that when I'm running `enduro start` or `enduro render` (basically deploying for production) it would generate already minified files. This was obviously done for my private reasons and purposes, but I might as well just share it. I imagine, since the change was really easy to make, there was a reason for it being that way and not the other (?).

PS. Since choice is always good, I also added additional flag, `--nominify` or just `-m`, so you can still deploy unminified, if you wanted to.