### PR TITLE
Fixed remote path from ./remote to ./_generated/remote on static server

### DIFF
--- a/libs/enduro_server/enduro_server.js
+++ b/libs/enduro_server/enduro_server.js
@@ -81,7 +81,7 @@ enduro_server.prototype.run = function (server_setup) {
 		app.use('/admin', express.static(enduro.config.admin_folder))
 		app.use('/assets', express.static(enduro.project_path + '/' + enduro.config.build_folder + '/assets'))
 		app.use('/_prebuilt', express.static(enduro.project_path + '/' + enduro.config.build_folder + '/_prebuilt'))
-		app.use('/remote', express.static(enduro.project_path + '/remote'))
+		app.use('/remote', express.static(enduro.project_path + '/' + enduro.config.build_folder + '/remote'))
 
 		// handle for executing enduro refresh from client
 		app.get('/admin_api_refresh', function (req, res) {


### PR DESCRIPTION
The static server is reading files from ./remote instead of ./_generated/remote. This pull request fixes this bug.