### PR TITLE
Propagate culture from temper to page renderer.

### DIFF
--- a/libs/page_rendering/page_renderer.js
+++ b/libs/page_rendering/page_renderer.js
@@ -131,12 +131,12 @@ page_renderer.prototype.render_file_by_template_path_extend_context = function (
 
 }
 
-page_renderer.prototype.render_file_by_template_path_replace_context = function (context_path, context) {
+page_renderer.prototype.render_file_by_template_path_replace_context = function (context_path, context, culture) {
 	const self = this
 	context = context || {}
 
 	const template_path = get_absolute_template_path_by_context_path(context_path)
-	const culture = enduro.config.cultures[0]
+	culture = culture || enduro.config.cultures[0]
 
 	return self.render_file_by_context(template_path, context, culture)
 }

--- a/libs/temper/temper.js
+++ b/libs/temper/temper.js
@@ -12,7 +12,7 @@ const page_renderer = require(enduro.enduro_path + '/libs/page_rendering/page_re
 const abstractor = require(enduro.enduro_path + '/libs/abstractor/abstractor')
 
 // Goes through the pages and renders them
-temper.prototype.render = function (filename, context) {
+temper.prototype.render = function (filename, context, culture) {
 
 	// use empty object if no context is provided
 	context = context || {}
@@ -21,7 +21,7 @@ temper.prototype.render = function (filename, context) {
 
 	return abstractor.abstract_context(context)
 		.then((context) => {
-			return page_renderer.render_file_by_template_path_replace_context(filename, context)
+			return page_renderer.render_file_by_template_path_replace_context(filename, context, culture)
 		})
 }
 


### PR DESCRIPTION
I didn't find any recommendation for contributors or if you accept any PRs. So, I made this one and I'm hoping it will find the way to the repo.
Motivation:
I needed to use `temper` with cms data. I use multilang support. The way `temper` is build, doesn't support any other culture than the first one.